### PR TITLE
Replace mathjax CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 				
 				//added by Pierre
 				math: {
-                                        mathjax: 'https://cdn.mathjax.org/mathjax/latest/MathJax.js',
+                                        mathjax: 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js',
                                         config: 'TeX-AMS_HTML-full'  // See http://docs.mathjax.org/en/latest/config-files.html
                                 },
 


### PR DESCRIPTION
Mathjax CDN will be shutting down on april 30, so this change uses the suggested CDN to replace the old one.

https://www.mathjax.org/cdn-shutting-down/